### PR TITLE
Handle inkscape 0.92 where no version string shows

### DIFF
--- a/tools/inkscape_extension/inkscape-1.1-hack/RUN.sh
+++ b/tools/inkscape_extension/inkscape-1.1-hack/RUN.sh
@@ -1,0 +1,53 @@
+#! /bin/sh
+
+wget="wget -nv --show-progress -c"
+dl_o=https://github.com/fablabnbg/VisiCut/releases/download/v1.8-310.1%2B20181009jw/
+vers_o=1.8-310.1+20181009jw
+vers_n=1.8-310.1+20181009+1jw
+
+mkdir -p 2018
+cd 2018
+$wget $dl/VisiCut-1.8-310.1+20181009jw-Windows-Installer.exe
+$wget $dl/visicut_1.8-310.1+20181009jw-1_all.deb
+$wget $dl/VisiCutMac-1.8-310.1+20181009jw.zip
+cd ..
+mkdir -p ext-1.1
+cd ext-1.1
+dl_e=https://raw.githubusercontent.com/t-oster/VisiCut/master/tools/inkscape_extension/
+$wget $dl_e/daemonize.py
+$wget $dl_e/visicut_export.py
+cd ..
+
+mkdir -p mac
+cd mac
+unzip -n ../2018/*Mac*.zip
+cp ../ext-1.1/* VisiCut.app/Contents/Resources/Java/inkscape_extension/
+sed -i -e "s/$vers_o/$vers_n/" VisiCut.app/Contents/Info.plist
+zip -r ../VisiCutMac-$vers_n.zip VisiCut.app
+cd ..
+
+mkdir -p lin
+dpkg-deb -R 2018/*.deb lin
+sed -i -e "s/$vers_o/$vers_n/" lin/DEBIAN/control
+cp ext-1.1/* lin/usr/share/visicut/inkscape_extension/
+dpkg-deb --build lin visicut_$vers_n-1_all.deb 
+
+mkdir -p win
+cd win
+7z x ../2018/*.exe
+cp ../ext-1.1/* inkscape_extension/
+cp ../2018/*.exe ../VisiCut-$vers_n-Windows-Installer.exe
+7z u ../VisiCut-$vers_n-Windows-Installer.exe inkscape_extension/daemonize.py  inkscape_extension/visicut_export.py
+####### ERROR:
+# Path = ../VisiCut-1.8-310.1+20181009+1jw-Windows-Installer.exe
+# Type = Nsis
+# Physical Size = 14745102
+# Method = Deflate
+# Solid = -
+# Headers Size = 59395
+# Embedded Stub Size = 88064
+# SubType = NSIS-2 BadCmd=11
+# 
+# System ERROR:
+# E_NOTIMPL
+####### ERROR:

--- a/tools/inkscape_extension/visicut_export.py
+++ b/tools/inkscape_extension/visicut_export.py
@@ -125,12 +125,14 @@ def which(program, extraPaths=[]):
 def inkscape_version():
     """determine if Inkscape is version 0 or 1"""
     version = subprocess.check_output([INKSCAPEBIN, "--version"],  stderr=DEVNULL).decode('ASCII', 'ignore')
-    assert version.startswith("Inkscape ")
-    if version.startswith("Inkscape 0"):
-        return 0
+    if version.startswith("Inkscape "):
+        if version.startswith("Inkscape 0"):
+            return 0
+        else:
+            return 1
     else:
-        return 1
-    
+        # sometimes in inkscape 0.92 under windows 10, we don't get the version string at all.
+        return 0
 
 
 # Strip SVG to only contain selected elements, convert objects to paths, unlink clones


### PR DESCRIPTION
Strange, but happens on windows 10, the `inkscape --version` call returns an empty line

