### PR TITLE
Enhancement: larger MappingBox

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/gui/mapping/MappingPanel.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/mapping/MappingPanel.java
@@ -93,6 +93,7 @@ public class MappingPanel extends javax.swing.JPanel
     private void initComponents() {
 
         predefinedMappingBox = new de.thomas_oster.visicut.gui.mapping.PredefinedMappingBox();
+        predefinedMappingBox.setMaximumRowCount(20);
         btProfileSettings = new javax.swing.JButton();
         jPanel1 = new javax.swing.JPanel();
         propertyMappingPanel = new de.thomas_oster.visicut.gui.mapping.PropertyMappingPanel();


### PR DESCRIPTION
Also upstreamed as https://github.com/t-oster/VisiCut/pull/697

This PR improves usability of the MappingBox by saving a few mouse miles:
 - whenever a file is loaded into visicut, the user has to choose a mapping. As this is a repetitive task, the clicks and mouse-movements should be as little as needed.
 - with custom defined mappings, (which I frequently use) the user has to 1) click open the combo box, 2) move the mouse into the widget (or its scrollbar). 3) scroll down (using mouse wheel or drag). 4) click to choose the mapping.

This PR simply extends the scrollbox to 20 elements,
- we we have plenty of empty space below, it usually does not obscure anything
- in case of a very small screen, the scrollbox automatically opens upwards, going ca 350 pixels high. This should always fit on the screen.
- user interaction is reduced to two clicks: open, choose.

Original size:
![grafik](https://github.com/t-oster/VisiCut/assets/1108546/eed20a5e-658b-4ea3-baf8-92e1cdb64c06)

----

New appearance:
![grafik](https://github.com/t-oster/VisiCut/assets/1108546/1440bb84-ceef-42dd-a299-813aee0e3c38)

----

New appearance, when there is little space below:
![grafik](https://github.com/t-oster/VisiCut/assets/1108546/0dd634e9-c557-4d7d-95f8-0b90e59c1bf7)